### PR TITLE
chore: add github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: BugSplat-Git/my-ubuntu-crasher
         path: my-ubuntu-crasher
@@ -32,14 +32,6 @@ jobs:
         bash handler.sh
         bash attachment.sh
         ls $PROJECT_DIR/out
-
-    # TODO BG try and remove this when node-dump-syms goes to 10.
-    # I think this is needed because node-pre-gyp is not a dev dependency in 9.2.2.
-    - name: Install node-dump-syms
-      if: runner.os == 'Linux'
-      run: |
-        npm i -g @mapbox/node-pre-gyp 
-        npm i -g node-dump-syms     
 
     - name: Upload Symbols
       uses: BugSplat-Git/symbol-upload@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,10 @@ jobs:
         #!/bin/bash
         cd scripts
         source exports.sh
+        echo $OUT_DIR
+        echo $PROJECT_DIR
+        echo $CRASHPAD_DIR
+        echo $MODULE_NAME
         mkdir -p $OUT_DIR
         bash compile.sh
         bash handler.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
     - name: Install node-dump-syms
       if: runner.os == 'Linux'
       run: |
+        npm i -g @mapbox/node-pre-gyp
         npm i -g node-dump-syms 
 
     - name: Upload Symbols

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,3 +44,4 @@ jobs:
         files: "myUbuntuCrasher"
         directory: "${{ env.PROJECT_DIR }}/out"
         dumpSyms: true
+        node-version: "22"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         npm i -g node-dump-syms 
 
     - name: Upload Symbols
-      uses: BugSplat-Git/symbol-upload@b488976f0946ee3f79f3d231fdc74d305da69b97
+      uses: BugSplat-Git/symbol-upload@main
       with:
         clientId: "${{ secrets.SYMBOL_UPLOAD_CLIENT_ID }}"
         clientSecret: "${{ secrets.SYMBOL_UPLOAD_CLIENT_SECRET }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,12 @@ jobs:
         bash attachment.sh
         ls $PROJECT_DIR/out
 
+    # TODO BG try and remove this when node-dump-syms goes to 10.
+    # I think this is needed because node-pre-gyp is not a dev dependency in 9.2.2.
+    - name: Install node-dump-syms
+      if: runner.os == 'Linux'
+      run: npm install -g @bugsplat/node-dump-syms     
+
     - name: Upload Symbols
       uses: BugSplat-Git/symbol-upload@d9ec6410f7230e35997a79ad8690bbf111cc6fcb
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
         bash compile.sh
         bash handler.sh
         bash attachment.sh
+        ls $PROJECT_DIR/out
 
     - name: Upload Symbols
       uses: BugSplat-Git/symbol-upload@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Build
+
+on:
+  push:
+
+jobs:
+  build-and-run:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        repository: BugSplat-Git/my-ubuntu-crasher
+        path: my-ubuntu-crasher
+
+    - name: Set PROJECT_DIR environment variable
+      run: echo "PROJECT_DIR=${{ github.workspace }}/my-ubuntu-crasher" >> $GITHUB_ENV
+
+    - name: Run script
+      working-directory: ${{ env.PROJECT_DIR }}
+      run: |
+        #!/bin/bash
+        cd scripts
+        source exports.sh
+        mkdir -p $OUT_DIR
+        bash compile.sh
+        bash handler.sh
+        bash attachment.sh
+
+    - name: Upload Symbols
+      uses: BugSplat-Git/symbol-upload@main
+      with:
+        clientId: "${{ secrets.SYMBOL_UPLOAD_CLIENT_ID }}"
+        clientSecret: "${{ secrets.SYMBOL_UPLOAD_CLIENT_SECRET }}"
+        database: "${{ secrets.BUGSPLAT_DATABASE }}"
+        application: "my-ubuntu-crasher"
+        version: "1.0.0"
+        files: "**/*.sym"
+        directory: "${{ env.PROJECT_DIR }}/out"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         ls $PROJECT_DIR/out
 
     - name: Upload Symbols
-      uses: BugSplat-Git/symbol-upload@main
+      uses: BugSplat-Git/symbol-upload@b488976f0946ee3f79f3d231fdc74d305da69b97
       with:
         clientId: "${{ secrets.SYMBOL_UPLOAD_CLIENT_ID }}"
         clientSecret: "${{ secrets.SYMBOL_UPLOAD_CLIENT_SECRET }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,12 @@ jobs:
         bash attachment.sh
         ls $PROJECT_DIR/out
 
+    # TODO BG not sure why this is required, but after fiddling with node-pre-gyp for a while I can't get it to work without this
+    - name: Install node-dump-syms
+      if: runner.os == 'Linux'
+      run: |
+        npm i -g node-dump-syms 
+
     - name: Upload Symbols
       uses: BugSplat-Git/symbol-upload@b488976f0946ee3f79f3d231fdc74d305da69b97
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         npm i -g node-dump-syms     
 
     - name: Upload Symbols
-      uses: BugSplat-Git/symbol-upload@d9ec6410f7230e35997a79ad8690bbf111cc6fcb
+      uses: BugSplat-Git/symbol-upload@main
       with:
         clientId: "${{ secrets.SYMBOL_UPLOAD_CLIENT_ID }}"
         clientSecret: "${{ secrets.SYMBOL_UPLOAD_CLIENT_SECRET }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
     # I think this is needed because node-pre-gyp is not a dev dependency in 9.2.2.
     - name: Install node-dump-syms
       if: runner.os == 'Linux'
-      run: npm install -g @bugsplat/node-dump-syms     
+      run: npm install -g node-dump-syms     
 
     - name: Upload Symbols
       uses: BugSplat-Git/symbol-upload@d9ec6410f7230e35997a79ad8690bbf111cc6fcb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,9 @@ jobs:
     # I think this is needed because node-pre-gyp is not a dev dependency in 9.2.2.
     - name: Install node-dump-syms
       if: runner.os == 'Linux'
-      run: npm install -g node-dump-syms     
+      run: |
+        npm i -g @mapbox/node-pre-gyp 
+        npm i -g node-dump-syms     
 
     - name: Upload Symbols
       uses: BugSplat-Git/symbol-upload@d9ec6410f7230e35997a79ad8690bbf111cc6fcb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,12 +34,13 @@ jobs:
         ls $PROJECT_DIR/out
 
     - name: Upload Symbols
-      uses: BugSplat-Git/symbol-upload@main
+      uses: BugSplat-Git/symbol-upload@d9ec6410f7230e35997a79ad8690bbf111cc6fcb
       with:
         clientId: "${{ secrets.SYMBOL_UPLOAD_CLIENT_ID }}"
         clientSecret: "${{ secrets.SYMBOL_UPLOAD_CLIENT_SECRET }}"
         database: "${{ secrets.BUGSPLAT_DATABASE }}"
         application: "my-ubuntu-crasher"
         version: "1.0.0"
-        files: "**/*.sym"
+        files: "myUbuntuCrasher"
         directory: "${{ env.PROJECT_DIR }}/out"
+        dumpSyms: true


### PR DESCRIPTION
### Description

Show an example of how to use the new dumpSyms flag from https://github.com/BugSplat-Git/symbol-upload/pull/136 in a GitHub action.

### TODO BG
- [x] pin the action to a tag instead of a commit hash

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
